### PR TITLE
Add GitHub actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Module CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  ci:
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      endtoend: false
+      phpcoverage_force_off: true
+      js: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.phpunit.result.cache
+/vendor/
+/resources
+/app
+/themes
+.test-output
+/composer.lock
+*.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # silverstripe-encrypt-at-rest
 
+![github actions](https://github.com/madmatt/silverstripe-encrypt-at-rest/actions/workflows/main.yml/badge.svg)
+
 This module allows Silverstripe CMS ORM data to be encrypted before being stored in the database, and automatically decrypted before using within your application. To do this, we use a secret key known only by the web server.
 
 

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,11 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "defuse/php-encryption": "^2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "source": "https://github.com/madmatt/silverstripe-encrypt-at-rest"
     },
     "require": {
-		"php": "^8.0",
+        "php": "^8.0",
         "silverstripe/framework": "^4.9.0",
         "defuse/php-encryption": "^2.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "source": "https://github.com/madmatt/silverstripe-encrypt-at-rest"
     },
     "require": {
+		"php": "^8.0",
         "silverstripe/framework": "^4.9.0",
         "defuse/php-encryption": "^2.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="silverstripe-encrypt-at-rest">
+    <directory>tests/</directory>
+  </testsuite>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
       <directory suffix=".php">tests/</directory>
     </exclude>
   </coverage>
+  <php>
+	  <!-- An example key for testing purposes, created with vendor/bin/generate-defuse-key -->
+    <env name="ENCRYPT_AT_REST_KEY" value="def000001ae7b3baf85422b623b0c0236d5c5c389049b4a277a413a2481fd4ebbc153cdf3c52bd3f97e599ca5094e04e52c3cebbab039d7514fa2e449794fdd1217c0ce9" />
+  </php>
   <testsuite name="silverstripe-encrypt-at-rest">
     <directory>tests/</directory>
   </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
     </exclude>
   </coverage>
   <php>
-	  <!-- An example key for testing purposes, created with vendor/bin/generate-defuse-key -->
+    <!-- An example key for testing purposes, created with vendor/bin/generate-defuse-key -->
     <env name="ENCRYPT_AT_REST_KEY" value="def000001ae7b3baf85422b623b0c0236d5c5c389049b4a277a413a2481fd4ebbc153cdf3c52bd3f97e599ca5094e04e52c3cebbab039d7514fa2e449794fdd1217c0ce9" />
   </php>
   <testsuite name="silverstripe-encrypt-at-rest">

--- a/tests/AtRestCryptoServiceTest.php
+++ b/tests/AtRestCryptoServiceTest.php
@@ -74,6 +74,12 @@ class AtRestCryptoServiceTest extends SapphireTest
             ? $assetStore->getProtectedFilesystem()->getAdapter()
             : $assetStore->getPublicFilesystem()->getAdapter();
 
+		// Check for existence of $adaptor->prefixPath() showing we are using SS5.0+
+		$prefixPath = 'applyPathPrefix';
+		if (method_exists($adapter, 'prefixPath')) {
+			$prefixPath = 'prefixPath';
+		}
+
         $file = File::create();
         $file->setFromString($originalText, $originalFilename);
         $file->write();
@@ -84,7 +90,7 @@ class AtRestCryptoServiceTest extends SapphireTest
             $file->publishFile();
         }
 
-        $oldFilename = $adapter->prefixPath(
+        $oldFilename = $adapter->$prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $file->getFilename(),
@@ -116,7 +122,7 @@ class AtRestCryptoServiceTest extends SapphireTest
         // Confirm the old file has been deleted
         $this->assertFileDoesNotExist($oldFilename);
 
-        $encryptedFilename = $adapter->prefixPath(
+        $encryptedFilename = $adapter->$prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $encryptedFile->getFilename(),
@@ -144,7 +150,7 @@ class AtRestCryptoServiceTest extends SapphireTest
 
         // Now decrypt the file back
         $decryptedFile = $service->decryptFile($encryptedFile, null, $visibility);
-        $decryptedFilename = $adapter->prefixPath(
+        $decryptedFilename = $adapter->$prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $decryptedFile->getFilename(),

--- a/tests/AtRestCryptoServiceTest.php
+++ b/tests/AtRestCryptoServiceTest.php
@@ -74,11 +74,11 @@ class AtRestCryptoServiceTest extends SapphireTest
             ? $assetStore->getProtectedFilesystem()->getAdapter()
             : $assetStore->getPublicFilesystem()->getAdapter();
 
-		// Check for existence of $adaptor->prefixPath() showing we are using SS5.0+
-		$prefixPath = 'applyPathPrefix';
-		if (method_exists($adapter, 'prefixPath')) {
-			$prefixPath = 'prefixPath';
-		}
+        // Check for existence of $adaptor->prefixPath() showing we are using SS5.0+
+        $prefixPath = 'applyPathPrefix';
+        if (method_exists($adapter, 'prefixPath')) {
+            $prefixPath = 'prefixPath';
+        }
 
         $file = File::create();
         $file->setFromString($originalText, $originalFilename);

--- a/tests/AtRestCryptoServiceTest.php
+++ b/tests/AtRestCryptoServiceTest.php
@@ -84,7 +84,7 @@ class AtRestCryptoServiceTest extends SapphireTest
             $file->publishFile();
         }
 
-        $oldFilename = $adapter->applyPathPrefix(
+        $oldFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $file->getFilename(),
@@ -102,9 +102,9 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename, $file->getFilename());
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $oldFilename);
+            $this->assertStringContainsString('assets/.protected/', $oldFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $oldFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $oldFilename);
         }
 
         /** @var AtRestCryptoService $service */
@@ -114,9 +114,9 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename . '.enc', $encryptedFile->getFilename());
 
         // Confirm the old file has been deleted
-        $this->assertFileNotExists($oldFilename);
+        $this->assertFileDoesNotExist($oldFilename);
 
-        $encryptedFilename = $adapter->applyPathPrefix(
+        $encryptedFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $encryptedFile->getFilename(),
@@ -130,20 +130,21 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertFileExists($encryptedFilename);
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $encryptedFilename);
+            $this->assertStringContainsString('assets/.protected/', $encryptedFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $encryptedFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $encryptedFilename);
         }
 
+        $encryptedFileString = $encryptedFile->getString() ?: '';
         // Confirm the new file is encrypted
-        $this->assertFalse(ctype_print($encryptedFile->getString()));
-        $this->assertNotEquals($originalText, $encryptedFile->getString());
+        $this->assertFalse(ctype_print($encryptedFileString));
+        $this->assertNotEquals($originalText, $encryptedFileString);
         $this->assertEquals($originalFilename, $encryptedFile->Name);
         $this->assertEquals($originalFilename . '.enc', $file->getFilename());
 
         // Now decrypt the file back
         $decryptedFile = $service->decryptFile($encryptedFile, null, $visibility);
-        $decryptedFilename = $adapter->applyPathPrefix(
+        $decryptedFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $decryptedFile->getFilename(),
@@ -160,16 +161,16 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename, $decryptedFile->getFilename());
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $decryptedFilename);
+            $this->assertStringContainsString('assets/.protected/', $decryptedFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $decryptedFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $decryptedFilename);
         }
 
         // Confirm that original text has been decoded properly
         $this->assertEquals($originalText, $decryptedFile->getString());
 
         // Confirm that encrypted file has been deleted
-        $this->assertFileNotExists($encryptedFilename);
+        $this->assertFileDoesNotExist($encryptedFilename);
     }
 
     /**


### PR DESCRIPTION
Adding the standard Silverstripe Github action to automatically run the tests against supported versions of php.

<img width="1429" alt="Screen Shot 2023-10-31 at 9 27 03 AM" src="https://github.com/madmatt/silverstripe-encrypt-at-rest/assets/415374/b681a7bb-1dc8-4341-802c-4b450c310332">

The tests will be run:
* When any code is pushed to the repo
* Monthly at midnight on the first day of the month - to catch external changes

In addition, I also upgraded phpunit to 9.6, with test changes copied from [the SS5 pull request](https://github.com/madmatt/silverstripe-encrypt-at-rest/pull/30), with SS4 compatibility added.